### PR TITLE
Add arm64 support for M1 Apple Silicon

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
       -
         name: Import GPG key
         id: import_gpg

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,7 @@ builds:
     - darwin
   goarch:
     - amd64
+    - arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ build:
 
 release:
 	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64
+	GOOS=darwin GOARCH=arm64 go build -o ./bin/${BINARY}_${VERSION}_darwin_arm64
 	GOOS=freebsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_freebsd_386
 	GOOS=freebsd GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_freebsd_amd64
 	GOOS=freebsd GOARCH=arm go build -o ./bin/${BINARY}_${VERSION}_freebsd_arm
@@ -30,8 +31,8 @@ install: build
 	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 
 test: 
-	go test -i $(TEST) || exit 1                                                   
-	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4                    
+	go test -i $(TEST) || exit 1
+	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: 
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m   
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/nrkno/terraform-provider-lastpass
 
-go 1.15
+go 1.16
 
 require github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.0


### PR DESCRIPTION
Upgrade Go to version 1.16 which natively supports arm64 for Darwin, meaning it now has native support for the M1 MacBooks.
No other changes required other than adding arm64 to the goarch param of goreleaser.
Tested on my M1 MacBook Pro without any issues.

Bumps version to 0.6.0